### PR TITLE
Allow custom call of logging.getLogger inside blocks of code

### DIFF
--- a/hulks/check_logger.py
+++ b/hulks/check_logger.py
@@ -17,6 +17,9 @@ class CheckLoggerHook(BaseHook):
             if 'getLogger(' not in line:
                 continue
 
+            if line.startswith((' ', '\t')):
+                continue
+
             matcher = re.search(pattern, line)
             if not matcher:
                 self._show_error_message(filename, lino)

--- a/tests/test_check_logger.py
+++ b/tests/test_check_logger.py
@@ -44,3 +44,19 @@ def test_check_logger_validate_pass(capsys, hook, text):
     assert hook.lines_iterator.called_once_with('whatever.txt')
     assert output == ''
     assert result is True
+
+
+@pytest.mark.parametrize('indentation', ('\t', ' ', ' ' * 4, ' ' * 8))
+def test_check_logger_validate_logger_inside_block_pass(capsys, hook, indentation):
+    lines = [
+        'def my_custom_logger(log_name):',
+        indentation + 'return logger.getLogger(log_name)',
+    ]
+    hook.lines_iterator = mock.Mock(
+        return_value=enumerate(lines, start=1),
+    )
+    result = hook.validate('whatever.txt')
+    output, _ = capsys.readouterr()
+    assert hook.lines_iterator.called_once_with('whatever.txt')
+    assert output == ''
+    assert result is True


### PR DESCRIPTION
If I want to create a custom "get logger" function the `check_logger` hooks fails, e.g.:

```python

def my_custom_get_logger(name):
    logger = logging.getLogger(name)
    return MyCustomLoggerAdapter(logger, ...)

my_custom_get_logger(__name__)
```

This PR updates the check logger to allow this kind of customization.

PS: I don't think the hook should properly validate custom loggers usage such as the last line of the example above.