### PR TITLE
Fix check mutable defaults for a module with many functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog
 ---------
 
 
+0.2.2
+~~~~~
+
+* Fix check-mutable-default to work correctly for modules with many functions and methods
+
+
 0.2.1
 ~~~~~
 

--- a/hulks/check_mutable_defaults.py
+++ b/hulks/check_mutable_defaults.py
@@ -49,13 +49,9 @@ class CheckMutableDefaults(BaseHook):
         return retval
 
     def validate(self, filename, **options):
-        retval = True
         parsed = ast.parse(open(filename).read(), filename)
         fn_nodes = self._collect_functions_with_defaults(parsed)
-        for node in fn_nodes:
-            retval = self._check_node_mutability(filename, node)
-
-        return retval
+        return all(self._check_node_mutability(filename, node) for node in fn_nodes)
 
 
 def main(args=None):

--- a/tests/test_check_mutable_defaults.py
+++ b/tests/test_check_mutable_defaults.py
@@ -41,6 +41,23 @@ def test_async_function_with_mutable_default(capsys, hook, content):
         assert '(foo)' in output
 
 
+def test_functions_with_mutable_default(capsys, hook):
+    content = """
+    \ndef foo(arg=[]):
+          pass
+
+    \ndef bar(arg=None):
+        pass
+    """
+
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('foo.py') is False
+        mock_file.assert_called_once_with('foo.py')
+
+        output, _ = capsys.readouterr()
+        assert '(foo)' in output
+
+
 @pytest.mark.parametrize('mutable_arg', ['[]', '{}', 'set()', 'list()', 'dict()', 'ValueError()'])
 def test_method_with_mutable_default(capsys, hook, mutable_arg):
     content = """


### PR DESCRIPTION
If a file had more than one function and the last didn't have mutable default even if all the others were wrong the check would consider the file as being correct. This PR fix this bug.