### PR TITLE
Improve check-mutable-default to verify for mutable elements on class attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ Changelog
 
 * Fixes config of invalid-domains hook to only check text files
 
+0.2.4
+~~~~~
+
+* Improve check-mutable-default to verify for mutable elements on class attributes
+
 0.2.3
 ~~~~~
 

--- a/hulks/check_mutable_defaults.py
+++ b/hulks/check_mutable_defaults.py
@@ -65,7 +65,7 @@ class CheckMutableDefaults(BaseHook):
 
             nodes += [
                 cls_node for cls_node in node.body
-                if isinstance(cls_node, ast.Assign)
+                if isinstance(cls_node, (ast.AnnAssign, ast.Assign))
             ]
 
         return nodes
@@ -74,7 +74,12 @@ class CheckMutableDefaults(BaseHook):
         retval = True
         if self._check_mutable_value(node.value):
             msg = 'mutable default found: {}:{}:{} ({})'
-            print(msg.format(filename, node.lineno, node.col_offset, node.targets[0].id))
+            try:
+                name = node.targets[0].id
+            except AttributeError:
+                name = node.target.id
+
+            print(msg.format(filename, node.lineno, node.col_offset, name))
             retval = False
 
         return retval

--- a/tests/test_check_mutable_defaults.py
+++ b/tests/test_check_mutable_defaults.py
@@ -172,3 +172,21 @@ def test_class_attribute_with_mutable_default(capsys, hook, mutable_arg):
 
         output, _ = capsys.readouterr()
         assert '(bar)' in output
+
+
+def test_annotated_class_attribute_with_mutable_default(capsys, hook):
+    content = """
+    \nclass A:
+        foo = None
+
+    \nclass B:
+        bar: typing.List[str] = []
+        baz = None
+    """
+
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('foo.py') is False
+        mock_file.assert_called_once_with('foo.py')
+
+        output, _ = capsys.readouterr()
+        assert '(bar)' in output

--- a/tests/test_check_mutable_defaults.py
+++ b/tests/test_check_mutable_defaults.py
@@ -138,23 +138,6 @@ def test_immutable_default(capsys, hook, prefix):
         assert output == ""
 
 
-def test_class_attribute_with_immutable_default(capsys, hook):
-    content = """
-    \nclass A:
-        foo = None
-
-    \nclass B:
-        baz = None
-    """
-
-    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
-        assert hook.validate('foo.py') is True
-        mock_file.assert_called_once_with('foo.py')
-
-        output, _ = capsys.readouterr()
-        assert output == ""
-
-
 @pytest.mark.parametrize('mutable_arg', ['[]', '{}', 'set()', 'list()', 'dict()', 'ValueError()'])
 def test_class_attribute_with_mutable_default(capsys, hook, mutable_arg):
     content = """
@@ -162,19 +145,46 @@ def test_class_attribute_with_mutable_default(capsys, hook, mutable_arg):
         foo = None
 
     \nclass B:
-        bar = {}
+        _bar = {0}
+        bar = {0}
+        BAR = {0}
         baz = None
     """.format(mutable_arg)
 
     with patch('builtins.open', mock_open(read_data=content)) as mock_file:
-        assert hook.validate('foo.py') is False
+        assert hook.validate('foo.py') is True
+        mock_file.assert_called_once_with('foo.py')
+
+        output, _ = capsys.readouterr()
+        assert '(bar)' not in output
+        assert '(BAR)' not in output
+        assert '(_bar)' not in output
+
+
+@pytest.mark.parametrize('mutable_arg', ['[]', '{}', 'set()', 'list()', 'dict()', 'ValueError()'])
+def test_strict_class_attribute_with_mutable_default(capsys, hook, mutable_arg):
+    content = """
+    \nclass A:
+        foo = None
+
+    \nclass B:
+        _bar = {0}
+        bar = {0}
+        BAR = {0}
+        baz = None
+    """.format(mutable_arg)
+
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('foo.py', strict=True) is False
         mock_file.assert_called_once_with('foo.py')
 
         output, _ = capsys.readouterr()
         assert '(bar)' in output
+        assert '(BAR)' not in output
+        assert '(_bar)' not in output
 
 
-def test_annotated_class_attribute_with_mutable_default(capsys, hook):
+def test_strict_annotated_class_attribute_with_mutable_default(capsys, hook):
     content = """
     \nclass A:
         foo = None
@@ -185,7 +195,7 @@ def test_annotated_class_attribute_with_mutable_default(capsys, hook):
     """
 
     with patch('builtins.open', mock_open(read_data=content)) as mock_file:
-        assert hook.validate('foo.py') is False
+        assert hook.validate('foo.py', strict=True) is False
         mock_file.assert_called_once_with('foo.py')
 
         output, _ = capsys.readouterr()


### PR DESCRIPTION
Atualmente o hulks possui uma verificação de elementos mutáveis que checa elementos mutáveis como valor padrão de argumentos de funções e isso pode trazer certos comportamentos indesejados para as aplicações.

Porém, esse problema não é reservado somente para arg padrão de funções, essa regra vale para todos elementos mutáveis instanciados em "tempo de import" [1] que tenham estado compartilhado como atributos de classe:

```python
In [4]: class Cart:
   ...:     products = []
   ...: 

In [5]: cart = Cart()

In [6]: cart.products.append('product1')

In [7]: cart.products
Out[7]: ['product1']

In [8]: another_cart = Cart()

In [10]: another_cart.products.append('product2')

In [11]: another_cart.products
Out[11]: ['product1', 'product2']
```

Este PR adiciona uma checagem que caça esses casos com alguns parametros que forneci num comentário abaixo (https://github.com/olist/hulks/pull/10#issuecomment-428702179)

[1] https://www.benkuhn.net/importtime