### PR TITLE
[LOL-400] Restrict domain-checking to text files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   entry: check-invalid-domains
   name: hulks.check_invalid_domains
   language: python
+  types: [text]
 
 - id: check-filename
   entry: check-filename

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+0.2.4
+~~~~~~
+
+* Fixes config of invalid-domains hook to only check text files
 
 0.2.3
 ~~~~~

--- a/hulks/check_django_migrations_filename.py
+++ b/hulks/check_django_migrations_filename.py
@@ -17,7 +17,7 @@ class DjangoMigrationFilenameHook(BaseHook):
             return False
 
         if re.match(self.CAMEL_CASE_PATTERN, filepath.name):
-            print('{}: {}'.format(filename, 'invalid migration filename, camel case detected' ))
+            print('{}: {}'.format(filename, 'invalid migration filename, camel case detected'))
             return False
 
         return True

--- a/hulks/check_logger.py
+++ b/hulks/check_logger.py
@@ -12,7 +12,7 @@ class CheckLoggerHook(BaseHook):
 
     def validate(self, filename, **options):
         retval = True
-        pattern = re.compile('\((.+)\)')
+        pattern = re.compile(r'\((.+)\)')
         for lino, line in self.lines_iterator(filename):
             if 'getLogger(' not in line:
                 continue


### PR DESCRIPTION
What
=====

Change configuration to skip binary file verification on 'invalid-domains' hook.

Why
====

The invalid-domains file hook was missing the config parameter
to only check for text files. This raises an error and makes it impossible
for projects using this hook to have any binary artifact checked in.

Task: https://jira-olist.atlassian.net/browse/LOL-400
History: https://jira-olist.atlassian.net/browse/LOL-401

CI link: https://circleci.com/gh/olist/hulks/