### PR TITLE
Fix check mutable default when a class attr receives a classmethod

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.2.7
+~~~~~
+
+* Fix check-mutable-default check to stop failing when a class attribute receives a classmethod instance
+
 0.2.6
 ~~~~~
 

--- a/tests/test_check_mutable_defaults.py
+++ b/tests/test_check_mutable_defaults.py
@@ -200,3 +200,22 @@ def test_strict_annotated_class_attribute_with_mutable_default(capsys, hook):
 
         output, _ = capsys.readouterr()
         assert '(bar)' in output
+
+
+def test_class_attribute_as_classmethod_call(capsys, hook):
+    content = """
+    \nclass Foo:
+        @classmethod
+        def foo(cls):
+            pass
+
+    \nclass B:
+        baz = Foo.foo()
+    """
+
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('foo.py') is True
+        mock_file.assert_called_once_with('foo.py')
+
+        output, _ = capsys.readouterr()
+        assert output == ""


### PR DESCRIPTION
When a class attribute receives a classmethod the check fails. The actual case that caused this was:

```python
class AddressFactory(Factory):
    class Meta:
        model = Address

    name = faker.Faker('name', locale='pt_BR')  # here
```

And the traceback:

```
hulks.check_mutable_defaults.............................................Failed
hookid: check-mutable-defaults

Traceback (most recent call last):
  ...
  File "/home/luiz/.cache/pre-commit/repolcepnw19/py_env-python3.7m/lib/python3.7/site-packages/hulks/check_mutable_defaults.py", line 74, in _check_assign_node_mutability
    if not self._check_mutable_value(node.value):
  File "/home/luiz/.cache/pre-commit/repolcepnw19/py_env-python3.7m/lib/python3.7/site-packages/hulks/check_mutable_defaults.py", line 55, in _check_mutable_value
    isinstance(value, ast.Call) and value.func.id not in self._immutable_builtins,
AttributeError: 'Attribute' object has no attribute 'id'
```

The quickfix included on this PR was to accept those kind of calls.

More on https://circleci.com/gh/olist/oss-total-express-broker/133