### PR TITLE
[TINB-92] - Add pre-commit hook to check print()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,11 +17,17 @@
 - id: check-logger
   entry: check-logger
   name: hulks.check_logger
-  language:  python
+  language: python
   types: [python]
 
 - id: check-mutable-defaults
   entry: check-mutable-defaults
   name: hulks.check_mutable_defaults
+  language: python
+  types: [python]
+
+- id: check-print
+  entry: check-print
+  name: hulks.check_print
   language: python
   types: [python]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.3.0
+~~~~~
+
+* Add new hook to check print statements in classes/methods/functions
+
 0.2.7
 ~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.3.0
 ~~~~~
 
-* Add new hook to check print statements in classes/methods/functions
+* Add new hook to check print statements in code
 
 0.2.7
 ~~~~~

--- a/hulks/check_print.py
+++ b/hulks/check_print.py
@@ -7,7 +7,7 @@ from hulks.base import BaseHook
 class CheckPrintHook(BaseHook):
 
     def _show_error_message(self, filename, line_number):
-        msg = '{}, line={}: there is a print() function, please remove it.'
+        msg = '{}, line={}: call to print found, please remove it.'
         print(msg.format(filename, line_number))
 
     def validate(self, filename, **options):

--- a/hulks/check_print.py
+++ b/hulks/check_print.py
@@ -1,0 +1,30 @@
+import ast
+import sys
+
+from hulks.base import BaseHook
+
+
+class CheckPrintHook(BaseHook):
+
+    def _show_error_message(self, filename, line_number):
+        msg = '{}, line={}: there is a print() function, please remove it.'
+        print(msg.format(filename, line_number))
+
+    def validate(self, filename, **options):
+        retval = True
+        parsed_tree = ast.parse(open(filename).read(), filename)
+        for node in ast.walk(parsed_tree):
+            if isinstance(node, ast.Name) and node.id == 'print':
+                self._show_error_message(filename, node.lineno)
+                retval = False
+        return retval
+
+
+def main(args=None):
+    """Checks 'print' usage"""
+    hook = CheckPrintHook()
+    sys.exit(hook.handle(args))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/tests/test_check_print.py
+++ b/tests/test_check_print.py
@@ -1,0 +1,90 @@
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from hulks.check_print import CheckPrintHook
+
+
+@pytest.fixture
+def hook():
+    return CheckPrintHook()
+
+
+@pytest.mark.parametrize('content', [
+    'print()',
+    "print('test')",
+    'print("test")',
+    'print ("test")',
+    'print(some_variable)',
+])
+def test_check_print_validate_error(capsys, hook, content):
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('whatever.py') is False
+        mock_file.assert_called_once_with('whatever.py')
+
+        output, _ = capsys.readouterr()
+
+        assert output.startswith('whatever.py')
+        assert 'line=1' in output
+
+
+@pytest.mark.parametrize('content', [
+    '_print()',
+    "__print('test')",
+    'print_something("test")',
+    '_print ("test")',
+    '_print(some_variable)',
+])
+def test_check_print_validate_pass(capsys, hook, content):
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('whatever.py') is True
+        mock_file.assert_called_once_with('whatever.py')
+
+        output, _ = capsys.readouterr()
+        assert '' in output
+
+
+def test_check_print_inside_block_validate_error(capsys, hook):
+    content = """
+    \nclass Whatever:
+        @classmethod
+        def print_something(cls):
+            print("something")
+
+    \ndef print_something_two():
+        print("something")
+
+    \nif True:
+        print("something")
+    """
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('whatever.py') is False
+        mock_file.assert_called_once_with('whatever.py')
+
+        output, _ = capsys.readouterr()
+
+        assert output.startswith('whatever.py')
+        assert 'line=6' in output
+        assert 'line=10' in output
+        assert 'line=14' in output
+
+
+def test_check_print_inside_block_validate_pass(capsys, hook):
+    content = """
+    \nclass Whatever:
+        @classmethod
+        def print_something(cls):
+            _print("something")
+
+    \ndef print_something_two():
+        print_foo("something")
+
+    \nif True:
+        __print("something")
+    """
+    with patch('builtins.open', mock_open(read_data=content)) as mock_file:
+        assert hook.validate('whatever.py') is True
+        mock_file.assert_called_once_with('whatever.py')
+
+        output, _ = capsys.readouterr()
+        assert '' in output


### PR DESCRIPTION
What
=====

Add new pre-commit hook to check if exists `print` statements into the codebase.

Why
====
To avoid run production code with `print` statements.

Test hook in another project:
```shell
python -m hulks.check_print tests/conftest.py
tests/conftest.py, line=284: call to print found, please remove it.
```


History: https://jira-olist.atlassian.net/browse/TINB-92

CI link: https://circleci.com/gh/olist/hulks/