### PR TITLE
Fix check mutable defaults hook to work on python < 3.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.4.1
+~~~~~
+
+* Fix check mutable defaults hook to work on python < 3.6
+
 0.4.0
 ~~~~~
 

--- a/hulks/check_mutable_defaults.py
+++ b/hulks/check_mutable_defaults.py
@@ -3,10 +3,16 @@ import sys
 
 from hulks.base import BaseHook
 
+_immutable_builtins = ("bool", "float", "frozenset", "int", "object", "str", "tuple")
+_ast_mutable_types = (ast.List, ast.Set, ast.Dict)
+try:
+    _assigns = (ast.AnnAssign, ast.Assign)
+except AttributeError:
+    # AnnAssign only exists on python>=3.6
+    _assigns = (ast.Assign,)
+
 
 class CheckMutableDefaults(BaseHook):
-    _immutable_builtins = ("bool", "float", "frozenset", "int", "object", "str", "tuple")
-    _ast_mutable_types = (ast.List, ast.Set, ast.Dict)
 
     def _collect_functions_with_defaults(self, tree):
         nodes = []
@@ -25,7 +31,7 @@ class CheckMutableDefaults(BaseHook):
             if not isinstance(node, ast.ClassDef):
                 continue
 
-            nodes += [cls_node for cls_node in node.body if isinstance(cls_node, (ast.AnnAssign, ast.Assign))]
+            nodes += [cls_node for cls_node in node.body if isinstance(cls_node, _assigns)]
 
         return nodes
 
@@ -33,11 +39,11 @@ class CheckMutableDefaults(BaseHook):
         if isinstance(value, ast.Tuple) and any(self._check_mutable_value(elt) for elt in value.elts):
             return True
 
-        if isinstance(value, self._ast_mutable_types):
+        if isinstance(value, _ast_mutable_types):
             return True
 
         try:
-            return value.func.id not in self._immutable_builtins
+            return value.func.id not in _immutable_builtins
         except AttributeError as exc:
             if isinstance(value, ast.Call) and not isinstance(value.func, ast.Attribute):
                 raise exc

--- a/tests/test_check_mutable_defaults.py
+++ b/tests/test_check_mutable_defaults.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -205,6 +206,7 @@ def test_strict_class_attribute_with_mutable_default(capsys, hook, mutable_arg):
         assert "(_bar)" not in output
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_strict_annotated_class_attribute_with_mutable_default(capsys, hook):
     content = """
     \nclass A:


### PR DESCRIPTION
The following error happens when running the `hulks.check_mutable_defaults` on python 3.5:

```
Traceback (most recent call last):
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/bin/check-mutable-defaults", line 8, in <module>
    sys.exit(main())
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/lib/python3.5/site-packages/hulks/check_mutable_defaults.py", line 111, in main
    sys.exit(hook.handle(args))
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/lib/python3.5/site-packages/hulks/base.py", line 23, in handle
    last_retval = self.validate(filename, **cmd_options)
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/lib/python3.5/site-packages/hulks/check_mutable_defaults.py", line 105, in validate
    return self._check_classes(parsed, filename) and self._check_functions(parsed, filename)
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/lib/python3.5/site-packages/hulks/check_mutable_defaults.py", line 99, in _check_classes
    cls_nodes = self._collect_class_attributes(parsed)
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/lib/python3.5/site-packages/hulks/check_mutable_defaults.py", line 41, in _collect_class_attributes
    cls_node for cls_node in node.body
  File "/root/.cache/pre-commit/repobbcr0ixy/py_env-python3.5/lib/python3.5/site-packages/hulks/check_mutable_defaults.py", line 42, in <listcomp>
    if isinstance(cls_node, (ast.AnnAssign, ast.Assign))
AttributeError: module 'ast' has no attribute 'AnnAssign'
```

The error occurs because python <= 3.5 doesn't support class attributes with type annotations. This patch fixes that.